### PR TITLE
dodanie page objectu Shop i kilku testów

### DIFF
--- a/cypress/Pages/ShopPage.js
+++ b/cypress/Pages/ShopPage.js
@@ -1,0 +1,30 @@
+class ShopPage {
+
+// getters
+
+    get productListElement() {
+        return cy.get('.products.content-wrap li');
+    }
+
+    get addToCartButton () {
+        return cy.get('.add_to_cart_button');
+    }
+
+
+// methods
+
+    visit() {
+        return cy.visit('/shop');
+    }
+
+    selectProduct(index) {
+        this.productListElement.eq(index).click()
+    }
+    
+    addToCart(index) {
+        this.addToCartButton.eq(index).click()
+    }
+  
+}
+
+export default ShopPage;

--- a/cypress/e2e/testBase.cy.js
+++ b/cypress/e2e/testBase.cy.js
@@ -1,6 +1,7 @@
 import HomePage from '../Pages/HomePage';
+import ShopPage from '../Pages/ShopPage';
 
-context('Login page', () => {
+context('Home page', () => {
 
 const homePage = new HomePage();
 
@@ -8,34 +9,42 @@ const homePage = new HomePage();
     homePage.visit();
   })
 
-   it('Selects Cart from the menu', () => {
+  it('Selects Cart from the menu', () => {
       homePage.selectFromMenu('Cart')
       cy.url().should('eq', Cypress.config().baseUrl + '/cart/')
-   })
+  })
 
-   it("Selects the 1st product from the list", () => {
+  it("Selects the 1st product from the list and opens it's page", () => {
     homePage.selectProduct(0)
     cy.url().should('include', '/produkt/')
-    
- })
+  })
 
-   it("Adds the 1st product from the list to the cart", () => {
+  it("Adds the 1st product from the list to the cart", () => {
     homePage.addToCart(0)
-  
- })
+  })
 
-   it("Tests the searching tool", () => {
+  it("Tests the searching tool", () => {
     homePage.search('mug')
     cy.url().should('eq', Cypress.config().baseUrl + '/?s=mug')
-  
- })
+  })
 
+})
 
+context.only('Shop page', () => {
 
+  const shopPage = new ShopPage();
 
+  beforeEach('Navigates to shop', () => {
+    shopPage.visit();
+  })
 
+  it("Selects the 1st product from the list and opens it's page", () => {
+    shopPage.selectProduct(0)
+    cy.url().should('include', '/produkt/')
+  })
 
-
-
+  it("Adds the 1st product from the list to the cart", () => {
+    shopPage.addToCart(0)
+  })
 
 })


### PR DESCRIPTION
Dodany page object do najważniejszej w sumie strony - sklepu, na razie zduplikowane testy co na home pagu już były.

Poza tym poprawiłem trochę stronkę:
- dodałem sklep w menu, bo do tej pory jedynym sposobem żeby do niego przejść to było zmieniając url
- zmieniłem nieco... tematykę naszej strony :D
- uporządkowałem trochę produkty, bo był bałagan w kategoriach - teraz każdy ma właściwą. Dodałem też jakieś żeby był co najmniej jeden do każdej kategorii.
- zrobiłem odnośniki do sklepu z home paga, teraz np. kliknięcie w kategorię tshirt przekierowuje do sklepu z filtrem na koszulki, zamiast na górę strony
- no i dodałem filtry w sklepie właśnie, na razie na kategorię i cenę, ale można więcej, jak będziemy chcieli tego typu testy pisać